### PR TITLE
Add support for building the code for multiple versions of Spark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,11 @@ jobs:
           command: |
             sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
             java -version
-            sbt clean test publish
+            for sparkVersion in 3.0.1 3.1.2 3.3.1 3.4.1 3.5.0
+            do
+              export SPARK_VERSION=$sparkVersion
+              sbt clean test publish
+            done
       - save_cache:
           paths:
             - ~/.sbt
@@ -83,7 +87,11 @@ jobs:
               git reset --hard HEAD~1
               git push origin master --tags
             else
-              sbt clean test publish
+              for sparkVersion in 3.0.1 3.1.2 3.3.1 3.4.1 3.5.0
+              do
+                export SPARK_VERSION=$sparkVersion
+                sbt clean test publish
+              done
             fi
       - save_cache:
           paths:
@@ -118,7 +126,13 @@ jobs:
       - run:
           name: Package the Jar
           command: |
-            sbt clean test package
+            sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+            java -version
+            for sparkVersion in 3.0.1 3.1.2 3.3.1 3.4.1 3.5.0
+            do
+              export SPARK_VERSION=$sparkVersion
+              sbt clean test package
+            done
       - save_cache:
           paths:
             - ~/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -3,19 +3,50 @@ name := "data-io"
 organization := "com.zeotap"
 
 scalaVersion := "2.12.14"
-version := "2.0.0"
+version := sys.env("SPARK_VERSION").asInstanceOf[String] + "_2.0.0"
 
 import ReleaseTransformations._
 
-val sparkVersion = "3.1.2"
+val sparkVersionMap = Map(
+  "3.0.1" -> Map(
+    "sparkTestingBaseVersion" -> "3.0.1_1.4.7",
+    "deltaName" -> "delta-core",
+    "deltaVersion" -> "0.8.0",
+  ),
+  "3.1.2" -> Map(
+    "sparkTestingBaseVersion" -> "3.1.2_1.4.7",
+    "deltaName" -> "delta-core",
+    "deltaVersion" -> "1.0.0",
+  ),
+  "3.3.1" -> Map(
+    "sparkTestingBaseVersion" -> "3.3.1_1.4.7",
+    "deltaName" -> "delta-core",
+    "deltaVersion" -> "2.3.0",
+  ),
+  "3.4.1" -> Map(
+    "sparkTestingBaseVersion" -> "3.4.1_1.4.7",
+    "deltaName" -> "delta-core",
+    "deltaVersion" -> "2.4.0",
+  ),
+  "3.5.0" -> Map(
+    "sparkTestingBaseVersion" -> "3.5.0_1.4.7",
+    "deltaName" -> "delta-spark",
+    "deltaVersion" -> "3.0.0",
+  ),
+)
+
+val sparkVersion = System.getenv("SPARK_VERSION")
+val sparkTestingBaseVersion = sparkVersionMap(sparkVersion)("sparkTestingBaseVersion")
+val deltaName = sparkVersionMap(sparkVersion)("deltaName")
+val deltaVersion = sparkVersionMap(sparkVersion)("deltaVersion")
 val beamVersion = "2.33.0"
 
 libraryDependencies ++= Seq(
     "com.fasterxml.jackson.module" % "jackson-module-paranamer" % "2.12.1",
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.1",
     "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.21.1",
-    "com.zeotap" %% "spark-property-tests" % "3.1.2",
-    "io.delta" %% "delta-core" % "1.0.1",
+    "com.zeotap" %% "spark-property-tests" % sparkVersion,
+    "io.delta" %% deltaName % deltaVersion,
     "mysql" % "mysql-connector-java" % "8.0.26",
     "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
     "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
@@ -32,6 +63,10 @@ libraryDependencies ++= Seq(
     "org.mockito" % "mockito-core" % "2.22.0" % Test,
     "org.testcontainers" % "mysql" % "1.16.0" % Test,
     "org.testcontainers" % "postgresql" % "1.16.0" % Test
+)
+
+dependencyOverrides ++= Seq(
+  "org.scalatest" %% "scalatest" % "3.0.9"
 )
 
 fork in Test := true

--- a/src/test/scala/com/zeotap/data/io/source/spark/constructs/LatestPathOpsTest.scala
+++ b/src/test/scala/com/zeotap/data/io/source/spark/constructs/LatestPathOpsTest.scala
@@ -21,6 +21,7 @@ class LatestPathOpsTest extends FunSuite with DataFrameSuiteBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    FileUtils.forceDelete(new File("src/test/resources/custom-input-format"))
 
     val testSchema = List(
       StructField("Common_DataPartnerID", IntegerType, true),
@@ -155,7 +156,7 @@ class LatestPathOpsTest extends FunSuite with DataFrameSuiteBase {
     )
     val actualPathsForPattern = LatestPathOps.getPathsForPattern(fileSystem, fullPathTemplate).map(x => x.toString).map(x => "src" + x.split("src")(1)).toList
 
-    assert(expectedPathsForPattern == actualPathsForPattern)
+    assert(expectedPathsForPattern.sorted == actualPathsForPattern.sorted)
     FileUtils.forceDelete(new File("src/test/resources/custom-input-format/yr=2021/mon=07/dt=20"))
     FileUtils.forceDelete(new File("src/test/resources/custom-input-format/yr=2021/mon=07/dt=21"))
   }

--- a/src/test/scala/com/zeotap/data/io/source/spark/constructs/LookBackOpsTest.scala
+++ b/src/test/scala/com/zeotap/data/io/source/spark/constructs/LookBackOpsTest.scala
@@ -20,6 +20,7 @@ class LookBackOpsTest extends FunSuite with DataFrameSuiteBase {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    FileUtils.forceDelete(new File("src/test/resources/custom-input-format"))
 
     val testSchema = List(
       StructField("Common_DataPartnerID", IntegerType, true),

--- a/src/test/scala/com/zeotap/data/io/source/spark/loader/DeltaSparkLoaderTest.scala
+++ b/src/test/scala/com/zeotap/data/io/source/spark/loader/DeltaSparkLoaderTest.scala
@@ -15,6 +15,8 @@ class DeltaSparkLoaderTest extends FunSuite with DataFrameSuiteBase {
     val inputDeltaPath2: String = "src/test/resources/custom-input-format/yr=2023/mon=02/dt=02"
 
     override def beforeAll(): Unit = {
+        System.setProperty("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        System.setProperty("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
         super.beforeAll()
 
         val testSchema = List(


### PR DESCRIPTION
JIRA: [ZP-15272](https://zeotap.atlassian.net/browse/ZP-15272)

Building the Jar for Spark versions 3.0.1, 3.1.2, 3.3.1, 3.4.1 and 3.5.0.
The required and supported Delta versions and Spark-testing-base versions have been added for the same.

[ZP-15272]: https://zeotap.atlassian.net/browse/ZP-15272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ